### PR TITLE
dependencies update due to MethodNotFound exception using CryptoExchange.Net 3.9.0

### DIFF
--- a/Bitmex.Net/Bitmex.Net.Client.csproj
+++ b/Bitmex.Net/Bitmex.Net.Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.4.91</Version>
+    <Version>1.4.92</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Bitmex.Net.Client</PackageId>
     <Authors>ridicoulous</Authors>
@@ -14,21 +14,22 @@
     <RepositoryUrl>https://github.com/ridicoulous/Bitmex.Net</RepositoryUrl>
     <PackageProjectUrl>https://github.com/ridicoulous/Bitmex.Net</PackageProjectUrl>
     <PackageTags>bitmex api-wrapper crypto exchange historical data</PackageTags>
-    <PackageReleaseNotes>03/03/2021 - dependencies update
-1/28/2021 - dependencies update
-1/26/2021 - added milliseconds accuracy to start/end time filters
-1/26/2021 - added auth in not auth methods for better rate limits
-1/26/2021 - fix boolean values serialization
-1/18/2021 - Fix typo at Get all price indices endpoint
-1/13/2021 - Wallet history fix
-1/11/2021 - base library update</PackageReleaseNotes>
+    <PackageReleaseNotes>7/13/2021 - dependencies update
+		03/03/2021 - dependencies update
+		1/28/2021 - dependencies update
+		1/26/2021 - added milliseconds accuracy to start/end time filters
+		1/26/2021 - added auth in not auth methods for better rate limits
+		1/26/2021 - fix boolean values serialization
+		1/18/2021 - Fix typo at Get all price indices endpoint
+		1/13/2021 - Wallet history fix
+		1/11/2021 - base library update</PackageReleaseNotes>
     <Description>Bitmex.Net is a .Net wrapper for the Bitmex API. It includes all features the API provides, REST API and Websocket, using clear and readable objects including but not limited to Reading market info, Placing and managing orders and Reading balances and funds</Description>  
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CryptoExchange.Net" Version="3.7.0" />
-    <PackageReference Include="CsvHelper" Version="25.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="CryptoExchange.Net" Version="3.9.0" />
+    <PackageReference Include="CsvHelper" Version="27.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   
 


### PR DESCRIPTION
had to update dependencies due to MethodNotFound.

Binance.Net requires CryptoExchange 3.9.0 and caused Bitmex client to stop working.
