### PR TITLE
Load all instruments on start up, more nullable values

### DIFF
--- a/Bitmex.Net/BitmexSymbolOrderBook.cs
+++ b/Bitmex.Net/BitmexSymbolOrderBook.cs
@@ -113,7 +113,7 @@ namespace Bitmex.Net.Client
             {
                 return;
             }
-            if (update.Data[0]?.Symbol != Symbol)
+            if (!update.Data.Any(x => x.Symbol == Symbol))
             {
                 return;
             }

--- a/Bitmex.Net/BitmexSymbolOrderBook.cs
+++ b/Bitmex.Net/BitmexSymbolOrderBook.cs
@@ -48,8 +48,8 @@ namespace Bitmex.Net.Client
         {
             isTestnet = isTest;
             _bitmexSocketClient = new BitmexSocketClient(new BitmexSocketClientOptions(isTest));
-            InstrumentIndex = _bitmexSocketClient.InstrumentsIndexesAndTicks[symbol].Index;
-            InstrumentTickSize = _bitmexSocketClient.InstrumentsIndexesAndTicks[symbol].TickSize;
+            InstrumentIndex = _bitmexSocketClient.GetIndexAndTickForInstrument(symbol).Index;
+            InstrumentTickSize = _bitmexSocketClient.GetIndexAndTickForInstrument(symbol).TickSize;
             if (symbol == "XBTUSD")
             {
                 InstrumentTickSize = 0.01m;
@@ -66,8 +66,8 @@ namespace Bitmex.Net.Client
         {
             isTestnet = options.IsTestnet;
             _bitmexSocketClient = bitmexSocketClient ?? new BitmexSocketClient(new BitmexSocketClientOptions(options.IsTestnet));
-            InstrumentIndex = options.InstrumentIndex ?? _bitmexSocketClient.InstrumentsIndexesAndTicks[symbol].Index;
-            InstrumentTickSize = options.TickSize.HasValue ? options.TickSize.Value : _bitmexSocketClient.InstrumentsIndexesAndTicks[symbol].TickSize;
+            InstrumentIndex = options.InstrumentIndex ?? _bitmexSocketClient.GetIndexAndTickForInstrument(symbol).Index;
+            InstrumentTickSize = options.TickSize.HasValue ? options.TickSize.Value : _bitmexSocketClient.GetIndexAndTickForInstrument(symbol).TickSize;
             if (symbol == "XBTUSD")
             {
                 InstrumentTickSize = 0.01m;

--- a/Bitmex.Net/Objects/Order.cs
+++ b/Bitmex.Net/Objects/Order.cs
@@ -25,7 +25,7 @@ namespace Bitmex.Net.Client.Objects
 
         [JsonProperty("side")]
         [JsonConverter(typeof(BitmexOrderSideConverter))]
-        public BitmexOrderSide Side { get; set; }
+        public BitmexOrderSide? Side { get; set; }
 
         [JsonProperty("simpleOrderQty")]
         public decimal? SimpleOrderQty { get; set; }
@@ -55,7 +55,7 @@ namespace Bitmex.Net.Client.Objects
         public string SettlCurrency { get; set; }
 
         [JsonProperty("ordType"), JsonConverter(typeof(BitmexOrderTypeConverter))]
-        public BitmexOrderType OrdType { get; set; }
+        public BitmexOrderType? OrdType { get; set; }
 
         [JsonProperty("timeInForce")]
         public string TimeInForce { get; set; }
@@ -70,7 +70,7 @@ namespace Bitmex.Net.Client.Objects
         public string ExDestination { get; set; }
 
         [JsonProperty("ordStatus"), JsonConverter(typeof(BitmexOrderStatusConverter))]
-        public BitmexOrderStatus Status { get; set; }
+        public BitmexOrderStatus? Status { get; set; }
 
         [JsonProperty("triggered")]
         public string Triggered { get; set; }

--- a/Bitmex.Net/Objects/Quote.cs
+++ b/Bitmex.Net/Objects/Quote.cs
@@ -13,14 +13,14 @@ namespace Bitmex.Net.Client.Objects
         [JsonProperty("symbol", Required = Required.Always)]
         public string Symbol { get; set; }
         [JsonProperty("bidSize")]
-        public decimal BidSize { get; set; }
+        public decimal? BidSize { get; set; }
 
         [JsonProperty("bidPrice")]
-        public decimal BidPrice { get; set; }
+        public decimal? BidPrice { get; set; }
         [JsonProperty("askPrice")]
-        public decimal AskPrice { get; set; }
+        public decimal? AskPrice { get; set; }
         [JsonProperty("askSize")]
-        public decimal AskSize { get; set; }
+        public decimal? AskSize { get; set; }
     }
 
 }


### PR DESCRIPTION
Since IExchangeClient.OrderStatus, IExchangeClient.OrderSide and IExchangeClient.OrderType are not nullable using these properties may throw NotImplementedException, especially while handling socket data.