### PR TITLE
Cryptoexchange upgrade + fixes

### DIFF
--- a/Bitmex.Net/Bitmex.Net.Client.csproj
+++ b/Bitmex.Net/Bitmex.Net.Client.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CryptoExchange.Net" Version="5.3.0" />
+    <PackageReference Include="CryptoExchange.Net" Version="5.3.1" />
     <PackageReference Include="CsvHelper" Version="27.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>

--- a/Bitmex.Net/BitmexBaseClient.cs
+++ b/Bitmex.Net/BitmexBaseClient.cs
@@ -115,7 +115,7 @@ namespace Bitmex.Net
                 uri,
                 method,
                 cancellationToken,
-                parameters?.OrderBy(p => p.Key).ToDictionary(p => p.Key, p => p.Value), //order matters for signing requests
+                parameters,
                 signed,
                 postPosition,
                 arraySerialization,

--- a/Bitmex.Net/BitmexClientOptions.cs
+++ b/Bitmex.Net/BitmexClientOptions.cs
@@ -30,19 +30,23 @@ namespace Bitmex.Net.Client
         {
             CommonApiOptions = new(isTest ? TestNetEndpoint : ProductionEndpoint);
             LogLevel = Microsoft.Extensions.Logging.LogLevel.Debug;
-            this.CommonApiOptions.RateLimiters.Add(new RateLimiter().AddTotalRateLimit(
-                ApiCredentials is null ? 30 : 120,
-                TimeSpan.FromMinutes(1)));
-            this.CommonApiOptions.RateLimiters.Add(new RateLimiter().AddEndpointLimit(
-                BitmexMarginClient.GetEndPointsWithAdditionalRateLimiter(CommonApiOptions.BaseAddress),
-                10,
-                TimeSpan.FromSeconds(1)));
-            this.CommonApiOptions.RateLimitingBehaviour = RateLimitingBehaviour.Wait;
         }
 
         public BitmexClientOptions(ApiCredentials apiCredentials, bool isTest) : this(isTest)
         {
             ApiCredentials = apiCredentials;
+            CommonApiOptions.RateLimiters.Add(
+                new RateLimiter().AddTotalRateLimit(
+                    ApiCredentials is null ? 30 : 120,
+                    TimeSpan.FromMinutes(1))
+            );
+            CommonApiOptions.RateLimiters.Add(
+                    new RateLimiter().AddEndpointLimit(
+                    BitmexMarginClient.GetEndPointsWithAdditionalRateLimiter(CommonApiOptions.BaseAddress),
+                    10,
+                    TimeSpan.FromSeconds(1))
+            );
+            CommonApiOptions.RateLimitingBehaviour = RateLimitingBehaviour.Wait;
         }
         // for cloning this instance only
         private BitmexClientOptions(BitmexClientOptions baseOn) : base(baseOn)

--- a/Bitmex.Net/BitmexSocketClientOptions.cs
+++ b/Bitmex.Net/BitmexSocketClientOptions.cs
@@ -24,9 +24,7 @@ namespace Bitmex.Net.Client
         /// <param name="key"></param>
         /// <param name="secret"></param>
         /// <param name="isTestnet"></param>
-        /// <param name=""></param>
         /// <param name="loadInstrumentIndexes">If you will subscribe to orderbook, set it to true, cause instrument index and tick size will be used for price calculation</param>
-        /// <param name="useMultiplexing"></param>
         public BitmexSocketClientOptions(string key, string secret, bool isTestnet = false, bool loadInstrumentIndexes = true) : this(isTestnet, loadInstrumentIndexes)
         {
             key.ValidateNotNull(nameof(key));
@@ -38,7 +36,6 @@ namespace Bitmex.Net.Client
         /// 
         /// </summary>
         /// <param name="isTestnet"></param>
-        /// <param name="useMultiplexing"></param>
         /// <param name="loadInstrumentIndexes">If you will subscribe to orderbook, set it to true, cause instrument index and tick size will be used for price calculation</param>
         public BitmexSocketClientOptions(bool isTestnet, bool loadInstrumentIndexes=true, SocketApiClientOptions commonStreamsOptions = null) : base()
         {

--- a/Bitmex.Net/Objects/WalletHistory.cs
+++ b/Bitmex.Net/Objects/WalletHistory.cs
@@ -50,6 +50,6 @@ namespace Bitmex.Net.Client.Objects
         public decimal MarginBalanceInBtc => MarginBalance ?? 0 / 10e7m;
 
         [JsonProperty("timestamp")]
-        public DateTime Timestamp { get; set; }
+        public DateTime? Timestamp { get; set; }
     }
 }


### PR DESCRIPTION
with v5.3.1 no need to order request parameters before sending the request
WalletHistory Timestamp should be nullable
fix ratelimiter, now it works: 120(it didn't work before) per minute for signed and 30 for unsigned + 10 per second for orders requests