### PR TITLE
New socket stream for nontrade updates, depreciated fields

### DIFF
--- a/Bitmex.Net/BitmexSocketClient.cs
+++ b/Bitmex.Net/BitmexSocketClient.cs
@@ -215,5 +215,9 @@ namespace Bitmex.Net.Client
             return await Task.WhenAll(tasks);
         }
 
+        public async Task UnsubscribeAsync(IEnumerable<UpdateSubscription> subscriptions)
+        {
+            await Task.WhenAll(subscriptions.Select(sub => UnsubscribeAsync(sub)));
+        }
     }
 }

--- a/Bitmex.Net/BitmexSocketClient.cs
+++ b/Bitmex.Net/BitmexSocketClient.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Bitmex.Net.Client.Interfaces;
+using Bitmex.Net.Client.Objects;
 using Bitmex.Net.Client.Objects.Socket;
 using Bitmex.Net.Client.Objects.Socket.Repsonses;
 using Bitmex.Net.Client.Objects.Socket.Requests;
@@ -19,17 +20,200 @@ using Newtonsoft.Json.Linq;
 
 namespace Bitmex.Net.Client
 {
-    public class BitmexSocketClient : BaseSocketClient, IBitmexSocketClient
+    public class BitmexSocketClient : BaseSocketClient, IBitmexSocketClient, IBitmexSocketStreamActions
     {
 
         public BitmexSocketClient() : this(BitmexSocketClientOptions.Default.Copy())
         {
         }
+
         public BitmexSocketClient(BitmexSocketClientOptions options) : base("Bitmex", options)
         {
-            SocketStreams = AddApiClient(new BitmexSocketStream(log, this, options));
+            MainSocketStreams = AddApiClient(new BitmexSocketStream(log, this, options));
+            NonTradeSocketStreams = AddApiClient(new BitmexSocketStream(log, this, options.CopyWithNonTradeSocketEndpoint()));
         }
-        public BitmexSocketStream SocketStreams { get; set; }
+        public BitmexSocketStream MainSocketStreams { get; set; }
+        public BitmexSocketStream NonTradeSocketStreams { get; set; }
+
+        #region events
+        #region NonTradeSocketStreams events
+        public event Action<BitmexSocketEvent<Announcement>> OnAnnouncementUpdate
+        {
+            add => NonTradeSocketStreams.OnAnnouncementUpdate += value;
+            remove => NonTradeSocketStreams.OnAnnouncementUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<Chat>> OnChatMessageUpdate
+        {
+            add => NonTradeSocketStreams.OnChatMessageUpdate += value;
+            remove => NonTradeSocketStreams.OnChatMessageUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<GlobalNotification>> OnGlobalNotificationUpdate
+        {
+            add => NonTradeSocketStreams.OnGlobalNotificationUpdate += value;
+            remove => NonTradeSocketStreams.OnGlobalNotificationUpdate -= value;
+        }
+        #endregion NonTradeSocketStreams events
+        #region MainSocketStreams events
+        public event Action<BitmexSocketEvent<ConnectedUsers>> OnChatConnectionUpdate
+        {
+            add => MainSocketStreams.OnChatConnectionUpdate += value;
+            remove => MainSocketStreams.OnChatConnectionUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<Funding>> OnFundingUpdate
+        {
+            add => MainSocketStreams.OnFundingUpdate += value;
+            remove => MainSocketStreams.OnFundingUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<Instrument>> OnInstrimentUpdate
+        {
+            add => MainSocketStreams.OnInstrimentUpdate += value;
+            remove => MainSocketStreams.OnInstrimentUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<Insurance>> OnInsuranceUpdate
+        {
+            add => MainSocketStreams.OnInsuranceUpdate += value;
+            remove => MainSocketStreams.OnInsuranceUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<Liquidation>> OnLiquidationUpdate
+        {
+            add => MainSocketStreams.OnLiquidationUpdate += value;
+            remove => MainSocketStreams.OnLiquidationUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<BitmexOrderBookEntry>> OnOrderBookL2_25Update
+        {
+            add => MainSocketStreams.OnOrderBookL2_25Update += value;
+            remove => MainSocketStreams.OnOrderBookL2_25Update -= value;
+        }
+        public event Action<BitmexSocketEvent<BitmexOrderBookEntry>> OnorderBookL2Update
+        {
+            add => MainSocketStreams.OnorderBookL2Update += value;
+            remove => MainSocketStreams.OnorderBookL2Update -= value;
+        }
+        public event Action<BitmexSocketEvent<BitmexOrderBookL10>> OnOrderBook10Update
+        {
+            add => MainSocketStreams.OnOrderBook10Update += value;
+            remove => MainSocketStreams.OnOrderBook10Update -= value;
+        }
+        public event Action<BitmexSocketEvent<Quote>> OnQuotesUpdate
+        {
+            add => MainSocketStreams.OnQuotesUpdate += value;
+            remove => MainSocketStreams.OnQuotesUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<Quote>> OnOneMinuteQuoteBinUpdate
+        {
+            add => MainSocketStreams.OnOneMinuteQuoteBinUpdate += value;
+            remove => MainSocketStreams.OnOneMinuteQuoteBinUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<Quote>> OnFiveMinuteQuoteBinUpdate
+        {
+            add => MainSocketStreams.OnFiveMinuteQuoteBinUpdate += value;
+            remove => MainSocketStreams.OnFiveMinuteQuoteBinUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<Quote>> OnOneHourQuoteBinUpdate
+        {
+            add => MainSocketStreams.OnOneHourQuoteBinUpdate += value;
+            remove => MainSocketStreams.OnOneHourQuoteBinUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<Quote>> OnDailyQuoteBinUpdate
+        {
+            add => MainSocketStreams.OnDailyQuoteBinUpdate += value;
+            remove => MainSocketStreams.OnDailyQuoteBinUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<Settlement>> OnSettlementUpdate
+        {
+            add => MainSocketStreams.OnSettlementUpdate += value;
+            remove => MainSocketStreams.OnSettlementUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<BitmexTrade>> OnTradeUpdate
+        {
+            add => MainSocketStreams.OnTradeUpdate += value;
+            remove => MainSocketStreams.OnTradeUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<TradeBin>> OnOneMinuteTradeBinUpdate
+        {
+            add => MainSocketStreams.OnOneMinuteTradeBinUpdate += value;
+            remove => MainSocketStreams.OnOneMinuteTradeBinUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<TradeBin>> OnFiveMinuteTradeBinUpdate
+        {
+            add => MainSocketStreams.OnFiveMinuteTradeBinUpdate += value;
+            remove => MainSocketStreams.OnFiveMinuteTradeBinUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<TradeBin>> OnOneHourTradeBinUpdate
+        {
+            add => MainSocketStreams.OnOneHourTradeBinUpdate += value;
+            remove => MainSocketStreams.OnOneHourTradeBinUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<TradeBin>> OnDailyTradeBinUpdate
+        {
+            add => MainSocketStreams.OnDailyTradeBinUpdate += value;
+            remove => MainSocketStreams.OnDailyTradeBinUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<Affiliate>> OnUserAffiliatesUpdate
+        {
+            add => MainSocketStreams.OnUserAffiliatesUpdate += value;
+            remove => MainSocketStreams.OnUserAffiliatesUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<Execution>> OnUserExecutionsUpdate
+        {
+            add => MainSocketStreams.OnUserExecutionsUpdate += value;
+            remove => MainSocketStreams.OnUserExecutionsUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<BitmexOrder>> OnUserOrdersUpdate
+        {
+            add => MainSocketStreams.OnUserOrdersUpdate += value;
+            remove => MainSocketStreams.OnUserOrdersUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<Margin>> OnUserMarginUpdate
+        {
+            add => MainSocketStreams.OnUserMarginUpdate += value;
+            remove => MainSocketStreams.OnUserMarginUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<BitmexPosition>> OnUserPositionsUpdate
+        {
+            add => MainSocketStreams.OnUserPositionsUpdate += value;
+            remove => MainSocketStreams.OnUserPositionsUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<Transaction>> OnUserTransactionsUpdate
+        {
+            add => MainSocketStreams.OnUserTransactionsUpdate += value;
+            remove => MainSocketStreams.OnUserTransactionsUpdate -= value;
+        }
+        public event Action<BitmexSocketEvent<Wallet>> OnUserWalletUpdate
+        {
+            add => MainSocketStreams.OnUserWalletUpdate += value;
+            remove => MainSocketStreams.OnUserWalletUpdate -= value;
+        }
+        #endregion MainSocketStreams events
+
+        public event Action OnPongReceived
+        {
+            add
+            {
+                MainSocketStreams.OnPongReceived += value;
+                NonTradeSocketStreams.OnPongReceived += value;
+            }
+            remove
+            {
+                MainSocketStreams.OnPongReceived -= value;
+                NonTradeSocketStreams.OnPongReceived -= value;
+            }
+        }
+        #endregion
+
+        public Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(Action<DataEvent<BitmexSocketEvent<BitmexOrderBookEntry>>> onData, string symbol = "", bool full = false, CancellationToken ct = default)
+            => MainSocketStreams.SubscribeToOrderBookUpdatesAsync(onData, symbol, full, ct);
+
+        public async Task<IEnumerable<CallResult<UpdateSubscription>>> SubscribeAsync(BitmexSubscribeRequest bitmexSubscribeRequest, CancellationToken ct = default)
+        {
+            var nontradeSub = bitmexSubscribeRequest.PopNonTradeSubscriptions();
+            var tasks = new List<Task<CallResult<UpdateSubscription>>>();
+            if (bitmexSubscribeRequest.Args.Any())
+                tasks.Add(MainSocketStreams.SubscribeAsync(bitmexSubscribeRequest, ct));
+            if (nontradeSub.Args.Any())
+                tasks.Add(NonTradeSocketStreams.SubscribeAsync(nontradeSub, ct));
+            return await Task.WhenAll(tasks);
+        }
 
     }
 }

--- a/Bitmex.Net/BitmexSocketClientOptions.cs
+++ b/Bitmex.Net/BitmexSocketClientOptions.cs
@@ -61,13 +61,21 @@ namespace Bitmex.Net.Client
         public static BitmexSocketClientOptions Default { get; set; } = new BitmexSocketClientOptions()
         {
         };
-        public SocketApiClientOptions CommonStreamsOptions { get;}
+        public SocketApiClientOptions CommonStreamsOptions { get; private set; }
         public bool IsTestnet { get; private set; }
 
 
         public BitmexSocketClientOptions Copy()
         {
             return new BitmexSocketClientOptions(this);
+        }
+
+        internal BitmexSocketClientOptions CopyWithNonTradeSocketEndpoint()
+        {
+            return new BitmexSocketClientOptions(this)
+            {
+                CommonStreamsOptions = new(this.CommonStreamsOptions, new($"{this.CommonStreamsOptions.BaseAddress}Platform"))
+            };
         }
 
     }

--- a/Bitmex.Net/BitmexSocketStream.cs
+++ b/Bitmex.Net/BitmexSocketStream.cs
@@ -25,7 +25,7 @@ using System.Threading.Tasks;
 
 namespace Bitmex.Net.Client
 {
-    public class BitmexSocketStream : SocketApiClient, IBitmexSocketStream
+    public class BitmexSocketStream : SocketApiClient
     {
         private static readonly Dictionary<string, BitmexInstrumentIndexWithTick> instrumentsIndexesAndTicks = new Dictionary<string, BitmexInstrumentIndexWithTick>();
         private static readonly SemaphoreSlim instumentGetWaiter = new(1,1);

--- a/Bitmex.Net/BitmexSymbolOrderBook.cs
+++ b/Bitmex.Net/BitmexSymbolOrderBook.cs
@@ -61,7 +61,7 @@ namespace Bitmex.Net.Client
             isTestnet = options.IsTestnet;
             usedNewSocketClient = bitmexSocketClient is null;
             var mainClient = bitmexSocketClient ?? new BitmexSocketClient(new BitmexSocketClientOptions(options.IsTestnet){LogLevel = options.LogLevel});
-            _bitmexSocketStream = (BitmexSocketStream)mainClient.SocketStreams;
+            _bitmexSocketStream = (BitmexSocketStream)mainClient.MainSocketStreams;
             InstrumentIndex = options.InstrumentIndex ?? _bitmexSocketStream.GetIndexAndTickForInstrument(symbol).Index;
             if (symbol == "XBTUSD")
             {   //this value is hardcoded

--- a/Bitmex.Net/Helpers/BitmexExtensions.cs
+++ b/Bitmex.Net/Helpers/BitmexExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using Bitmex.Net.Client.Attributes;
+using Bitmex.Net.Client.Converters;
 using Bitmex.Net.Client.Objects;
 using Bitmex.Net.Client.Objects.Requests;
+using Bitmex.Net.Client.Objects.Socket;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -104,6 +106,25 @@ namespace Bitmex.Net.Client.Helpers.Extensions
             else
                 throw new ArgumentException("Unsupported timespan for Bitmex Candles, check supported intervals");
         }
+
+        public static bool IsItNonTradeSubscriptionString(this object subscriptionArg)
+        {
+            if (subscriptionArg is string subArg)
+            {
+                foreach (var topic in GetNonTradeSubscriptions())
+                {
+                    if (subArg.Contains(JsonConvert.SerializeObject(topic, new BitmexWebsocketTableConverter(false))))
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+        private static List<BitmexSubscribtions> GetNonTradeSubscriptions()
+        {
+            return new() { BitmexSubscribtions.Announcements, BitmexSubscribtions.Chat, BitmexSubscribtions.PublicNotifications };
+        }
     }
     public static class BitmexRequestExtensions
     {
@@ -202,5 +223,6 @@ namespace Bitmex.Net.Client.Helpers.Extensions
         {
             return filter.AddFilter("timestamp.month", $"{year}-{month}");
         }
+        
     }
 }

--- a/Bitmex.Net/Interfaces/IBitmexSocketClient.cs
+++ b/Bitmex.Net/Interfaces/IBitmexSocketClient.cs
@@ -7,6 +7,8 @@ namespace Bitmex.Net.Client.Interfaces
 {
     public interface IBitmexSocketClient
     {
-        BitmexSocketStream SocketStreams { get; }
+        BitmexSocketStream MainSocketStreams { get; }
+        BitmexSocketStream NonTradeSocketStreams { get; }
+
     }
 }

--- a/Bitmex.Net/Interfaces/IBitmexSocketStream.cs
+++ b/Bitmex.Net/Interfaces/IBitmexSocketStream.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace   Bitmex.Net.Client.Interfaces
 {
-    public interface IBitmexSocketStream
+    public interface IBitmexSocketStreamActions
     {
         event Action<BitmexSocketEvent<Announcement>> OnAnnouncementUpdate;
         event Action<BitmexSocketEvent<Chat>> OnChatMessageUpdate;
@@ -45,7 +45,7 @@ namespace   Bitmex.Net.Client.Interfaces
         event Action<BitmexSocketEvent<Transaction>> OnUserTransactionsUpdate;
         event Action<BitmexSocketEvent<Wallet>> OnUserWalletUpdate;
 
-        Task<CallResult<UpdateSubscription>> SubscribeAsync(BitmexSubscribeRequest bitmexSubscribeRequest, CancellationToken ct = default);
+        Task<IEnumerable<CallResult<UpdateSubscription>>> SubscribeAsync(BitmexSubscribeRequest bitmexSubscribeRequest, CancellationToken ct = default);
 
         /// subscribe to orderbook updates
         /// </summary>

--- a/Bitmex.Net/Objects/Execution.cs
+++ b/Bitmex.Net/Objects/Execution.cs
@@ -38,17 +38,8 @@ namespace    Bitmex.Net.Client.Objects
         [JsonProperty("lastPx")]
         public decimal? LastPx { get; set; }
 
-        [JsonProperty("underlyingLastPx")]
-        public decimal? UnderlyingLastPx { get; set; }
-
-        [JsonProperty("lastMkt")]
-        public string LastMkt { get; set; }
-
         [JsonProperty("lastLiquidityInd")]
         public string LastLiquidityInd { get; set; }
-
-        [JsonProperty("simpleOrderQty")]
-        public decimal? SimpleOrderQty { get; set; }
 
         [JsonProperty("orderQty")]
         public decimal? OrderQty { get; set; }
@@ -89,9 +80,6 @@ namespace    Bitmex.Net.Client.Objects
         [JsonProperty("contingencyType")]
         public string ContingencyType { get; set; }
 
-        [JsonProperty("exDestination")]
-        public string ExDestination { get; set; }
-
         [JsonProperty("ordStatus")]
         public string OrdStatus { get; set; }
 
@@ -104,14 +92,8 @@ namespace    Bitmex.Net.Client.Objects
         [JsonProperty("ordRejReason")]
         public string OrdRejReason { get; set; }
 
-        [JsonProperty("simpleLeavesQty")]
-        public decimal? SimpleLeavesQty { get; set; }
-
         [JsonProperty("leavesQty")]
         public decimal? LeavesQty { get; set; }
-
-        [JsonProperty("simpleCumQty")]
-        public decimal? SimpleCumQty { get; set; }
 
         [JsonProperty("cumQty")]
         public decimal? CumQty { get; set; }
@@ -124,9 +106,6 @@ namespace    Bitmex.Net.Client.Objects
 
         [JsonProperty("tradePublishIndicator")]
         public string TradePublishIndicator { get; set; }
-
-        [JsonProperty("multiLegReportingType")]
-        public string MultiLegReportingType { get; set; }
 
         [JsonProperty("text")]
         public string Text { get; set; }

--- a/Bitmex.Net/Objects/Instrument.cs
+++ b/Bitmex.Net/Objects/Instrument.cs
@@ -36,27 +36,6 @@ namespace Bitmex.Net.Client.Objects
         [JsonProperty("relistInterval")]
         public System.DateTime? RelistInterval { get; set; }
 
-        [JsonProperty("inverseLeg")]
-        public string InverseLeg { get; set; }
-
-        [JsonProperty("sellLeg")]
-        public string SellLeg { get; set; }
-
-        [JsonProperty("buyLeg")]
-        public string BuyLeg { get; set; }
-
-        [JsonProperty("optionStrikePcnt")]
-        public decimal? OptionStrikePcnt { get; set; }
-
-        [JsonProperty("optionStrikeRound")]
-        public decimal? OptionStrikeRound { get; set; }
-
-        [JsonProperty("optionStrikePrice")]
-        public decimal? OptionStrikePrice { get; set; }
-
-        [JsonProperty("optionMultiplier")]
-        public decimal? OptionMultiplier { get; set; }
-
         [JsonProperty("positionCurrency")]
         public string PositionCurrency { get; set; }
 
@@ -132,9 +111,6 @@ namespace Bitmex.Net.Client.Objects
         [JsonProperty("limit")]
         public decimal? Limit { get; set; }
 
-        [JsonProperty("capped")]
-        public bool? Capped { get; set; }
-
         [JsonProperty("taxed")]
         public bool? Taxed { get; set; }
 
@@ -149,9 +125,6 @@ namespace Bitmex.Net.Client.Objects
 
         [JsonProperty("settlementFee")]
         public decimal? SettlementFee { get; set; }
-
-        [JsonProperty("insuranceFee")]
-        public decimal? InsuranceFee { get; set; }
 
         [JsonProperty("fundingBaseSymbol")]
         public string FundingBaseSymbol { get; set; }
@@ -180,15 +153,6 @@ namespace Bitmex.Net.Client.Objects
         [JsonProperty("rebalanceInterval")]
         public System.DateTime? RebalanceInterval { get; set; }
 
-        [JsonProperty("openingTimestamp")]
-        public System.DateTime? OpeningTimestamp { get; set; }
-
-        [JsonProperty("closingTimestamp")]
-        public System.DateTime? ClosingTimestamp { get; set; }
-
-        [JsonProperty("sessionInterval")]
-        public System.DateTime? SessionInterval { get; set; }
-
         [JsonProperty("prevClosePrice")]
         public decimal? PrevClosePrice { get; set; }
 
@@ -197,15 +161,6 @@ namespace Bitmex.Net.Client.Objects
 
         [JsonProperty("limitUpPrice")]
         public decimal? LimitUpPrice { get; set; }
-
-        [JsonProperty("bankruptLimitDownPrice")]
-        public decimal? BankruptLimitDownPrice { get; set; }
-
-        [JsonProperty("bankruptLimitUpPrice")]
-        public decimal? BankruptLimitUpPrice { get; set; }
-
-        [JsonProperty("prevTotalVolume")]
-        public decimal? PrevTotalVolume { get; set; }
 
         [JsonProperty("totalVolume")]
         public decimal? TotalVolume { get; set; }
@@ -303,14 +258,8 @@ namespace Bitmex.Net.Client.Objects
         [JsonProperty("markPrice")]
         public decimal? MarkPrice { get; set; }
 
-        [JsonProperty("indicativeTaxRate")]
-        public decimal? IndicativeTaxRate { get; set; }
-
         [JsonProperty("indicativeSettlePrice")]
         public decimal? IndicativeSettlePrice { get; set; }
-
-        [JsonProperty("optionUnderlyingPrice")]
-        public decimal? OptionUnderlyingPrice { get; set; }
 
         [JsonProperty("settledPrice")]
         public decimal? SettledPrice { get; set; }

--- a/Bitmex.Net/Objects/Margin.cs
+++ b/Bitmex.Net/Objects/Margin.cs
@@ -19,32 +19,14 @@ namespace    Bitmex.Net.Client.Objects
         [JsonProperty("riskLimit")]
         public decimal? RiskLimit { get; set; }
 
-        [JsonProperty("prevState")]
-        public string PrevState { get; set; }
-
         [JsonProperty("state")]
         public string State { get; set; }
-
-        [JsonProperty("action")]
-        public string Action { get; set; }
 
         [JsonProperty("amount")]
         public decimal? Amount { get; set; }
 
-        [JsonProperty("pendingCredit")]
-        public decimal? PendingCredit { get; set; }
-
-        [JsonProperty("pendingDebit")]
-        public decimal? PendingDebit { get; set; }
-
-        [JsonProperty("confirmedDebit")]
-        public decimal? ConfirmedDebit { get; set; }
-
         [JsonProperty("prevRealisedPnl")]
         public decimal? PrevRealisedPnl { get; set; }
-
-        [JsonProperty("prevUnrealisedPnl")]
-        public decimal? PrevUnrealisedPnl { get; set; }
 
         [JsonProperty("grossComm")]
         public decimal? GrossComm { get; set; }
@@ -64,23 +46,14 @@ namespace    Bitmex.Net.Client.Objects
         [JsonProperty("riskValue")]
         public decimal? RiskValue { get; set; }
 
-        [JsonProperty("taxableMargin")]
-        public decimal? TaxableMargin { get; set; }
-
         [JsonProperty("initMargin")]
         public decimal? InitMargin { get; set; }
 
         [JsonProperty("maintMargin")]
         public decimal? MaintMargin { get; set; }
 
-        [JsonProperty("sessionMargin")]
-        public decimal? SessionMargin { get; set; }
-
         [JsonProperty("targetExcessMargin")]
         public decimal? TargetExcessMargin { get; set; }
-
-        [JsonProperty("varMargin")]
-        public decimal? VarMargin { get; set; }
 
         [JsonProperty("realisedPnl")]
         public decimal? RealisedPnl { get; set; }
@@ -88,23 +61,11 @@ namespace    Bitmex.Net.Client.Objects
         [JsonProperty("unrealisedPnl")]
         public decimal? UnrealisedPnl { get; set; }
 
-        [JsonProperty("indicativeTax")]
-        public decimal? IndicativeTax { get; set; }
-
-        [JsonProperty("unrealisedProfit")]
-        public decimal? UnrealisedProfit { get; set; }
-
-        [JsonProperty("syntheticMargin")]
-        public decimal? SyntheticMargin { get; set; }
-
         [JsonProperty("walletBalance")]
         public decimal? WalletBalance { get; set; }
 
         [JsonProperty("marginBalance")]
         public decimal? MarginBalance { get; set; }
-
-        [JsonProperty("marginBalancePcnt")]
-        public decimal? MarginBalancePcnt { get; set; }
 
         [JsonProperty("marginLeverage")]
         public decimal? MarginLeverage { get; set; }
@@ -114,9 +75,6 @@ namespace    Bitmex.Net.Client.Objects
 
         [JsonProperty("excessMargin")]
         public decimal? ExcessMargin { get; set; }
-
-        [JsonProperty("excessMarginPcnt")]
-        public decimal? ExcessMarginPcnt { get; set; }
 
         [JsonProperty("availableMargin")]
         public decimal? AvailableMargin { get; set; }

--- a/Bitmex.Net/Objects/Order.cs
+++ b/Bitmex.Net/Objects/Order.cs
@@ -27,9 +27,6 @@ namespace Bitmex.Net.Client.Objects
         [JsonConverter(typeof(BitmexOrderSideConverter))]
         public BitmexOrderSide? Side { get; set; }
 
-        [JsonProperty("simpleOrderQty")]
-        public decimal? SimpleOrderQty { get; set; }
-
         [JsonProperty("orderQty")]
         public decimal? OrderQty { get; set; }
 
@@ -66,9 +63,6 @@ namespace Bitmex.Net.Client.Objects
         [JsonProperty("contingencyType")]
         public string ContingencyType { get; set; }
 
-        [JsonProperty("exDestination")]
-        public string ExDestination { get; set; }
-
         [JsonProperty("ordStatus"), JsonConverter(typeof(BitmexOrderStatusConverter))]
         public BitmexOrderStatus? Status { get; set; }
 
@@ -81,23 +75,14 @@ namespace Bitmex.Net.Client.Objects
         [JsonProperty("ordRejReason")]
         public string OrdRejReason { get; set; }
 
-        [JsonProperty("simpleLeavesQty")]
-        public decimal? SimpleLeavesQty { get; set; }
-
         [JsonProperty("leavesQty")]
         public decimal? LeavesQty { get; set; }
-
-        [JsonProperty("simpleCumQty")]
-        public decimal? SimpleCumQty { get; set; }
 
         [JsonProperty("cumQty")]
         public decimal? CumQty { get; set; }
 
         [JsonProperty("avgPx")]
         public decimal? AvgPx { get; set; }
-
-        [JsonProperty("multiLegReportingType")]
-        public string MultiLegReportingType { get; set; }
 
         [JsonProperty("text")]
         public string Text { get; set; }

--- a/Bitmex.Net/Objects/Position.cs
+++ b/Bitmex.Net/Objects/Position.cs
@@ -54,20 +54,8 @@ namespace    Bitmex.Net.Client.Objects
         [JsonProperty("prevUnrealisedPnl")]
         public decimal? PrevUnrealisedPnl { get; set; }
 
-        [JsonProperty("prevClosePrice")]
-        public decimal? PrevClosePrice { get; set; }
-
-        [JsonProperty("openingTimestamp")]
-        public System.DateTime? OpeningTimestamp { get; set; }
-
         [JsonProperty("openingQty")]
         public decimal? OpeningQty { get; set; }
-
-        [JsonProperty("openingCost")]
-        public decimal? OpeningCost { get; set; }
-
-        [JsonProperty("openingComm")]
-        public decimal? OpeningComm { get; set; }
 
         [JsonProperty("openOrderBuyQty")]
         public decimal? OpenOrderBuyQty { get; set; }
@@ -87,30 +75,6 @@ namespace    Bitmex.Net.Client.Objects
         [JsonProperty("openOrderSellPremium")]
         public decimal? OpenOrderSellPremium { get; set; }
 
-        [JsonProperty("execBuyQty")]
-        public decimal? ExecBuyQty { get; set; }
-
-        [JsonProperty("execBuyCost")]
-        public decimal? ExecBuyCost { get; set; }
-
-        [JsonProperty("execSellQty")]
-        public decimal? ExecSellQty { get; set; }
-
-        [JsonProperty("execSellCost")]
-        public decimal? ExecSellCost { get; set; }
-
-        [JsonProperty("execQty")]
-        public decimal? ExecQty { get; set; }
-
-        [JsonProperty("execCost")]
-        public decimal? ExecCost { get; set; }
-
-        [JsonProperty("execComm")]
-        public decimal? ExecComm { get; set; }
-
-        [JsonProperty("currentTimestamp")]
-        public System.DateTime? CurrentTimestamp { get; set; }
-
         [JsonProperty("currentQty")]
         public decimal? CurrentQty { get; set; }
 
@@ -126,14 +90,8 @@ namespace    Bitmex.Net.Client.Objects
         [JsonProperty("unrealisedCost")]
         public decimal? UnrealisedCost { get; set; }
 
-        [JsonProperty("grossOpenCost")]
-        public decimal? GrossOpenCost { get; set; }
-
         [JsonProperty("grossOpenPremium")]
         public decimal? GrossOpenPremium { get; set; }
-
-        [JsonProperty("grossExecCost")]
-        public decimal? GrossExecCost { get; set; }
 
         [JsonProperty("isOpen")]
         public bool? IsOpen { get; set; }
@@ -159,14 +117,8 @@ namespace    Bitmex.Net.Client.Objects
         [JsonProperty("posCost")]
         public decimal? PosCost { get; set; }
 
-        [JsonProperty("posCost2")]
-        public decimal? PosCost2 { get; set; }
-
         [JsonProperty("posCross")]
         public decimal? PosCross { get; set; }
-
-        [JsonProperty("posInit")]
-        public decimal? PosInit { get; set; }
 
         [JsonProperty("posComm")]
         public decimal? PosComm { get; set; }
@@ -180,56 +132,14 @@ namespace    Bitmex.Net.Client.Objects
         [JsonProperty("posMaint")]
         public decimal? PosMaint { get; set; }
 
-        [JsonProperty("posAllowance")]
-        public decimal? PosAllowance { get; set; }
-
-        [JsonProperty("taxableMargin")]
-        public decimal? TaxableMargin { get; set; }
-
         [JsonProperty("initMargin")]
         public decimal? InitMargin { get; set; }
 
         [JsonProperty("maintMargin")]
         public decimal? MaintMargin { get; set; }
 
-        [JsonProperty("sessionMargin")]
-        public decimal? SessionMargin { get; set; }
-
-        [JsonProperty("targetExcessMargin")]
-        public decimal? TargetExcessMargin { get; set; }
-
-        [JsonProperty("varMargin")]
-        public decimal? VarMargin { get; set; }
-
-        [JsonProperty("realisedGrossPnl")]
-        public decimal? RealisedGrossPnl { get; set; }
-
-        [JsonProperty("realisedTax")]
-        public decimal? RealisedTax { get; set; }
-
         [JsonProperty("realisedPnl")]
         public decimal? RealisedPnlAfterRebalancing { get; set; }
-
-        [JsonProperty("unrealisedGrossPnl")]
-        public decimal? UnrealisedGrossPnl { get; set; }
-
-        [JsonProperty("longBankrupt")]
-        public decimal? LongBankrupt { get; set; }
-
-        [JsonProperty("shortBankrupt")]
-        public decimal? ShortBankrupt { get; set; }
-
-        [JsonProperty("taxBase")]
-        public decimal? TaxBase { get; set; }
-
-        [JsonProperty("indicativeTaxRate")]
-        public decimal? IndicativeTaxRate { get; set; }
-
-        [JsonProperty("indicativeTax")]
-        public decimal? IndicativeTax { get; set; }
-
-        [JsonProperty("unrealisedTax")]
-        public decimal? UnrealisedTax { get; set; }
 
         [JsonProperty("unrealisedPnl")]
         public decimal? UnrealisedPnl { get; set; }
@@ -239,24 +149,6 @@ namespace    Bitmex.Net.Client.Objects
 
         [JsonProperty("unrealisedRoePcnt")]
         public decimal? UnrealisedRoePcnt { get; set; }
-
-        [JsonProperty("simpleQty")]
-        public decimal? SimpleQty { get; set; }
-
-        [JsonProperty("simpleCost")]
-        public decimal? SimpleCost { get; set; }
-
-        [JsonProperty("simpleValue")]
-        public decimal? SimpleValue { get; set; }
-
-        [JsonProperty("simplePnl")]
-        public decimal? SimplePnl { get; set; }
-
-        [JsonProperty("simplePnlPcnt")]
-        public decimal? SimplePnlPcnt { get; set; }
-
-        [JsonProperty("avgCostPrice")]
-        public decimal? AvgCostPrice { get; set; }
 
         [JsonProperty("avgEntryPrice")]
         public decimal? AvgEntryPrice { get; set; }
@@ -276,11 +168,6 @@ namespace    Bitmex.Net.Client.Objects
         [JsonProperty("timestamp")]
         public System.DateTime? Timestamp { get; set; }
 
-        [JsonProperty("lastPrice")]
-        public decimal? LastPrice { get; set; }
-
-        [JsonProperty("lastValue")]
-        public decimal? LastValue { get; set; }
         /// <summary>
         /// for closed positions it equal to PrevRealisedPnl, for closed ones it equal to RealisedPnlAfterRebalancing + RebalancedPnl
         /// in a case of socket update use with cautions: some fields required for calculation may be null

--- a/Bitmex.Net/Objects/Socket/Requests/BitmexSubscribeRequest.cs
+++ b/Bitmex.Net/Objects/Socket/Requests/BitmexSubscribeRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Bitmex.Net.Client.Converters;
+using Bitmex.Net.Client.Helpers.Extensions;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -56,5 +57,17 @@ namespace Bitmex.Net.Client.Objects.Socket.Requests
                 Op = BitmexWebSocketOperation.Unsubscribe
             };
         }
+
+        /// <summary>
+        /// Moves the subscription topics from the request that should be sent to the different endpoint into one more BitmexSubscribeRequest
+        /// </summary>
+        /// <returns>new BitmexSubscribeRequest with nontrade topics only</returns>
+        internal BitmexSubscribeRequest PopNonTradeSubscriptions()
+        {
+            var nonTradeArgs = Args.Where(arg => arg.IsItNonTradeSubscriptionString()).ToList();
+            Args.RemoveAll(x => nonTradeArgs.Contains(x));
+            return new BitmexSubscribeRequest(nonTradeArgs);
+        }
+
     }
 }

--- a/Bitmex.Net/Objects/Socket/Requests/BitmexSubscribeRequest.cs
+++ b/Bitmex.Net/Objects/Socket/Requests/BitmexSubscribeRequest.cs
@@ -13,14 +13,7 @@ namespace Bitmex.Net.Client.Objects.Socket.Requests
         {
             Op = BitmexWebSocketOperation.Subscribe;
         }    
-        public BitmexSubscribeRequest(BitmexWebSocketOperation op, params string[] args)
-        {
-            Op = op;
-            foreach (var a in args)
-            {
-                Args.Add(a);
-            }
-        }
+
         public BitmexSubscribeRequest(params object[] args)
         {
             Op = BitmexWebSocketOperation.Subscribe;

--- a/Bitmex.Net/Objects/Socket/Requests/BitmexSubscribeRequest.cs
+++ b/Bitmex.Net/Objects/Socket/Requests/BitmexSubscribeRequest.cs
@@ -18,6 +18,7 @@ namespace Bitmex.Net.Client.Objects.Socket.Requests
         public BitmexSubscribeRequest(params object[] args)
         {
             Op = BitmexWebSocketOperation.Subscribe;
+            Args.AddRange(args);
         }
         [JsonProperty("args")]        
         public List<object> Args { get; set; } = new List<object> { };
@@ -64,7 +65,7 @@ namespace Bitmex.Net.Client.Objects.Socket.Requests
         /// <returns>new BitmexSubscribeRequest with nontrade topics only</returns>
         internal BitmexSubscribeRequest PopNonTradeSubscriptions()
         {
-            var nonTradeArgs = Args.Where(arg => arg.IsItNonTradeSubscriptionString()).ToList();
+            var nonTradeArgs = Args.Where(arg => arg.IsItNonTradeSubscriptionString()).ToArray(); //ToArray() because BitmexSubscribeRequest(params ...) ctor requires array
             Args.RemoveAll(x => nonTradeArgs.Contains(x));
             return new BitmexSubscribeRequest(nonTradeArgs);
         }

--- a/Bitmex.Net/Objects/Wallet.cs
+++ b/Bitmex.Net/Objects/Wallet.cs
@@ -11,38 +11,6 @@ namespace Bitmex.Net.Client.Objects
 
         public string Currency { get; set; }
 
-        [JsonProperty("prevDeposited")]
-        public decimal PrevDeposited { get; set; }
-
-        [JsonProperty("prevWithdrawn")]
-        public decimal PrevWithdrawn { get; set; }
-
-        [JsonProperty("prevTransferIn")]
-        public decimal PrevTransferIn { get; set; }
-
-        [JsonProperty("prevTransferOut")]
-        public decimal PrevTransferOut { get; set; }
-
-        [JsonProperty("prevAmount")]
-        public decimal PrevAmount { get; set; }
-
-        [JsonProperty("prevTimestamp")]
-        public System.DateTime? PrevTimestamp { get; set; }
-
-        [JsonProperty("deltaDeposited")]
-        public decimal DeltaDeposited { get; set; }
-
-        [JsonProperty("deltaWithdrawn")]
-        public decimal DeltaWithdrawn { get; set; }
-
-        [JsonProperty("deltaTransferIn")]
-        public decimal DeltaTransferIn { get; set; }
-
-        [JsonProperty("deltaTransferOut")]
-        public decimal DeltaTransferOut { get; set; }
-
-        [JsonProperty("deltaAmount")]
-        public decimal DeltaAmount { get; set; }
 
         [JsonProperty("deposited")]
         public decimal Deposited { get; set; }


### PR DESCRIPTION
Bitmex.com separates nontrade socket endpoint from the main one. This PR handles that update.