### PR TITLE
move GetWalletAssetsAsync() to trade client 

### DIFF
--- a/Bitmex.Net/BitmexBaseTradeClient.cs
+++ b/Bitmex.Net/BitmexBaseTradeClient.cs
@@ -63,6 +63,7 @@ namespace Bitmex.Net
         private const string UserMarginEndpoint = "user/margin";
         private const string UserCommunicationTokenEndpoint = "user/communicationToken";
         private const string UserEventEndpoint = "userEvent";
+        private const string WalletAssetsEndpoint = "wallet/assets";
 
         #endregion
         protected BitmexBaseTradeClient(string name, BitmexClientOptions options, Log log, BitmexClient client) : base(name, options, log, client)
@@ -408,6 +409,13 @@ namespace Bitmex.Net
             var parameters = GetParameters();
             parameters.Add("currency", currency);
             return await SendRequestAsync<Margin>(UserMarginEndpoint, HttpMethod.Get, ct, parameters);
+        }
+        #endregion
+        #region Assets
+        ///<inheritdoc/>
+        public async Task<WebCallResult<List<WalletAsset>>> GetWalletAssetsAsync(CancellationToken ct = default)
+        {
+            return await SendRequestAsync<List<WalletAsset>>(WalletAssetsEndpoint, HttpMethod.Get, ct);
         }
         #endregion
 

--- a/Bitmex.Net/BitmexNonTradeFeatureClient.cs
+++ b/Bitmex.Net/BitmexNonTradeFeatureClient.cs
@@ -31,8 +31,6 @@ namespace Bitmex.Net
         private const string LeaderBoardByNameEndpoint = "leaderboard/name";
         private const string Schemandpoint = "schema";
         private const string SchemaWebsokcetHelpEndpoint = "schema/websocketHelp";
-        private const string WalletAssetsEndpoint = "wallet/assets";
-
         #endregion
 
         internal BitmexNonTradeFeatureClient(string name, BitmexClientOptions options, Log log, BitmexClient client) : base(name, options, log, client)
@@ -112,12 +110,6 @@ namespace Bitmex.Net
         public async Task<WebCallResult<object>> GetWebsokcetHelpAsync(CancellationToken ct = default)
         {
             return await SendRequestAsync<object>(SchemaWebsokcetHelpEndpoint, HttpMethod.Get, ct);
-        }
-        #endregion
-        #region Assets
-        public async Task<WebCallResult<List<WalletAsset>>> GetWalletAssetsAsync(CancellationToken ct = default)
-        {
-            return await SendRequestAsync<List<WalletAsset>>(WalletAssetsEndpoint, HttpMethod.Get, ct);
         }
         #endregion
 

--- a/Bitmex.Net/Interfaces/IBitmexCommonTradeClient.cs
+++ b/Bitmex.Net/Interfaces/IBitmexCommonTradeClient.cs
@@ -272,6 +272,14 @@ namespace Bitmex.Net.Client.Interfaces
         /// <param name="ct"></param>
         /// <returns></returns>
         Task<WebCallResult<List<Execution>>> GetUserExecutionHistoryAsync(BitmexRequestWithFilter requestWithFilter = null, CancellationToken ct = default);
+        #endregion 
+        #region Assets
+        /// <summary>
+        /// Get Assets Config
+        /// </summary>
+        /// <param name="ct"></param>
+        /// <returns></returns>
+        Task<WebCallResult<List<WalletAsset>>> GetWalletAssetsAsync(CancellationToken ct = default);
         #endregion
     }
 }

--- a/Bitmex.Net/Interfaces/IBitmexNonTradeFeaturesClient.cs
+++ b/Bitmex.Net/Interfaces/IBitmexNonTradeFeaturesClient.cs
@@ -90,8 +90,6 @@ namespace Bitmex.Net.Client.Interfaces
         /// <returns></returns>
         Task<WebCallResult<object>> GetWebsokcetHelpAsync(CancellationToken ct = default);
         #endregion
-        #region Assets
-        public Task<WebCallResult<List<WalletAsset>>> GetWalletAssetsAsync(CancellationToken ct = default);
-        #endregion
+
     }
 }


### PR DESCRIPTION
I move GetWalletAssetsAsync() method to BitmexBaseTradeClient/IBitmexCommonTradeClient class/interface where other trading features are.